### PR TITLE
basic support for nix based development environment

### DIFF
--- a/leetcode-hs.cabal
+++ b/leetcode-hs.cabal
@@ -22,7 +22,7 @@ extra-source-files: CHANGELOG.md
 
 common common-settings
   build-depends:
-    , base        ^>=4.14.3.0
+    , base        >=4.14.3.0 && <4.17
     , containers
 
   default-language: Haskell2010
@@ -88,6 +88,6 @@ test-suite leetcode-tests
 
   hs-source-dirs: test
   build-depends:
-    , base           ^>=4.14.3.0
+    , base           >=4.14.3.0 && <4.17
     , hspec          >=2.7
     , leetcode-core

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,38 @@
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
+
+let
+
+  inherit (nixpkgs) pkgs;
+
+  f = { mkDerivation, base, containers, hspec, lib }:
+      mkDerivation {
+        pname = "leetcode-hs";
+        version = "0.1.0.0";
+        src = ./.;
+        isLibrary = false;
+        isExecutable = true;
+        libraryHaskellDepends = [ base containers ];
+        executableHaskellDepends = [ base containers ];
+        testHaskellDepends = [ base hspec ];
+        doHaddock = false;
+        license = lib.licenses.mit;
+        mainProgram = "leetcode-hs";
+      };
+
+  haskellPackages = if compiler == "default"
+                       then pkgs.haskellPackages
+                       else pkgs.haskell.packages.${compiler};
+
+  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
+
+  drv = variant (haskellPackages.callPackage f {});
+
+in
+  pkgs.mkShell {
+    buildInputs = with pkgs.haskellPackages; [
+      ghc
+      cabal-install
+      hlint
+      drv
+    ];
+  }


### PR DESCRIPTION
Add basic support for nix based development environment.
It's very simple now, just add essential haskell dependencies, and not currently compatible with official haskell vscode plugin. But we could use `Haskell Syntax Highlighting` and `haskell-linter`  and `Simple GHC (Haskell) Integration
` as replacement.

